### PR TITLE
Bugfix: Behebe Compilerfehler in \SetzeSchrift

### DIFF
--- a/bewerbung-latex.sty
+++ b/bewerbung-latex.sty
@@ -77,7 +77,7 @@
     \else%
         \setmainfont{#3}
     \fi%
-    \KOMAoption{fontsize=#1}%
+    \KOMAoptions{fontsize=#1}%
 }%
 
 % Sprache einstellen


### PR DESCRIPTION
Beim Kompilieren mit TeX Live 2022 und KOMA-Script 3.28 tritt der
folgende Fehler auf:

> ! Package scrbase Error: syntax error in key `fontsize=12pt'.
>
> See the scrbase package documentation for explanation.
> Type  H <return>  for immediate help.
>  ...
>
> l.30 ...zeSchrift[12pt]{tgpagella}{TeX Gyre Pagella}

Die Ursache ist der Aufruf von `\KOMAoption{fontsize=#1}` innerhalb des
Befehls \SetzeSchrift. Die Dokumentation von KOMA-Script beschreibt zwei
Befehle zum setzen von Optionen
```tex
\KOMAoptions{Optionenliste}
\KOMAoption{Option}{Werteliste}
```
Der Aufruf von `\KOMAoption{fontsize=#1}` ist also nicht gültig. Benutze
stattdessen `\KOMAoptions{fontsize=#1}`.